### PR TITLE
feature/checkbox_size

### DIFF
--- a/src/components/Checkbox/CheckIcons.tsx
+++ b/src/components/Checkbox/CheckIcons.tsx
@@ -1,0 +1,17 @@
+export interface IIconPath {
+  [name: string]: {
+    path: string;
+    viewBox: string;
+  };
+}
+
+export const CheckIcons: IIconPath = {
+  ['checkbox-outline']: {
+    path: 'M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z',
+    viewBox: '0 0 24 24',
+  },
+  ['checkbox-fill']: {
+    path: 'M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z',
+    viewBox: '0 0 24 24',
+  },
+};

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -1,53 +1,72 @@
-import React, { useState, FC } from 'react';
+import React, { useState, FC, InputHTMLAttributes } from 'react';
+import { classNames } from '../../utils/classNames';
+import { CheckIcons } from './CheckIcons';
 
-export type CheckboxColor = 'primary' | 'secondary';
+export type CheckboxColor = 'primary' | 'secondary' | 'default';
 export type CheckboxSize = 'medium' | 'small';
+export type CheckboxIcon = 'checkbox' | 'heart';
 
 export interface ICheckboxProps {
   checkColor?: CheckboxColor;
   checkSize?: CheckboxSize;
-  icon?: any;
+  icon?: CheckboxIcon;
   label?: string;
   onChange?: (e?: React.MouseEvent) => void;
   isChecked?: boolean;
 }
 
-export const Checkbox: FC<ICheckboxProps> = (props) => {
-  const { checkColor, checkSize, icon, label, onChange, isChecked, ...rest } =
-    props;
+export type NativeCheckboxProps = ICheckboxProps &
+  InputHTMLAttributes<HTMLInputElement>;
+
+export const Checkbox: FC<NativeCheckboxProps> = (props) => {
+  const {
+    checkColor = 'default',
+    checkSize = 'medium',
+    icon = 'checkbox',
+    label = '',
+    onChange,
+    isChecked = false,
+    ...rest
+  } = props;
   const [checked, setChecked] = useState(false);
 
-  const handleCheck = (e: any) => {
+  let checkSizeStyle = classNames({
+    [`checkbox-${checkSize}`]: true,
+  });
+
+  const handleCheck = (e: React.ChangeEvent<HTMLInputElement>) => {
     setChecked(e.target.checked);
   };
 
   return (
     <>
       <label className="form-control">
-        <span className="checkbox-container">
+        <span className={`checkbox-container ${checkSizeStyle}`}>
           <input type="checkbox" onChange={handleCheck} />
           {checked ? (
             <svg
-              width="24px"
-              height="24px"
-              viewBox="0 0 24 24"
+              className={checkSizeStyle}
+              viewBox={CheckIcons[`${icon}-fill`].viewBox}
               xmlns="http://www.w3.org/2000/svg"
+              aria-hidden="true"
+              focusable="false"
             >
               <path
                 fill="rgba(0, 0, 0, 0.54)"
-                d="M7 5a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2H7zm4 10.414-2.707-2.707 1.414-1.414L11 12.586l3.793-3.793 1.414 1.414L11 15.414z"
+                d={CheckIcons[`${icon}-fill`].path}
               />
             </svg>
           ) : (
             <svg
-              width="24px"
-              height="24px"
-              viewBox="0 0 24 24"
+              className={checkSizeStyle}
+              viewBox={CheckIcons[`${icon}-outline`].viewBox}
               xmlns="http://www.w3.org/2000/svg"
+              aria-hidden="true"
+              focusable="false"
             >
               <path
                 fill="rgba(0, 0, 0, 0.54)"
-                d="M7 5c-1.103 0-2 .897-2 2v10c0 1.103.897 2 2 2h10c1.103 0 2-.897 2-2V7c0-1.103-.897-2-2-2H7zm0 12V7h10l.002 10H7z"
+                d={CheckIcons[`${icon}-outline`].path}
               />
             </svg>
           )}

--- a/src/components/Checkbox/_Checkbox.scss
+++ b/src/components/Checkbox/_Checkbox.scss
@@ -2,8 +2,6 @@
   display: flex;
   align-items: center;
   cursor: pointer;
-  margin-left: -11px;
-  margin-right: 16px;
   font-family: Arial, Helvetica, sans-serif;
 
   .checkbox-container {
@@ -11,8 +9,6 @@
     align-items: center;
     justify-content: center;
     position: relative;
-    height: 42px;
-    width: 42px;
 
     input[type='checkbox'] {
       cursor: pointer;
@@ -35,3 +31,17 @@
     visibility: visible;
   }
 }
+
+@include checkbox-sm(
+  $checkbox-sm-width,
+  $checkbox-sm-height,
+  $checkbox-container-sm-width,
+  $checkbox-container-sm-height
+);
+
+@include checkbox-md(
+  $checkbox-md-width,
+  $checkbox-md-height,
+  $checkbox-container-md-width,
+  $checkbox-container-md-height
+);

--- a/src/styles/_mixin.scss
+++ b/src/styles/_mixin.scss
@@ -28,8 +28,13 @@
   }
 }
 
-
-@mixin message-style($msg-background-color, $msg-border-radius, $msg-border, $msg-padding, $msg-box-width) {
+@mixin message-style(
+  $msg-background-color,
+  $msg-border-radius,
+  $msg-border,
+  $msg-padding,
+  $msg-box-width
+) {
   background-color: $msg-background-color;
   border-radius: $msg-border-radius;
   border: $msg-border;
@@ -73,4 +78,38 @@
   border-width: $border-width;
   border-radius: $border-radius;
   border-color: $border-color;
+}
+
+@mixin checkbox-sm(
+  $checkbox-sm-width,
+  $checkbox-sm-height,
+  $checkbox-container-sm-width,
+  $checkbox-container-sm-height
+) {
+  .checkbox-container.checkbox-small {
+    height: $checkbox-container-sm-height;
+    width: $checkbox-container-sm-width;
+  }
+
+  .checkbox-small {
+    height: $checkbox-sm-height;
+    width: $checkbox-sm-width;
+  }
+}
+
+@mixin checkbox-md(
+  $checkbox-md-width,
+  $checkbox-md-height,
+  $checkbox-container-md-width,
+  $checkbox-container-md-height
+) {
+  .checkbox-container.checkbox-medium {
+    height: $checkbox-container-md-height;
+    width: $checkbox-container-md-width;
+  }
+
+  .checkbox-medium {
+    height: $checkbox-md-height;
+    width: $checkbox-md-width;
+  }
 }

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -293,3 +293,15 @@ $pg-circular-sm-text-size: 12px;
 $pg-circular-md-text-size: 16px;
 $pg-circular-lg-text-size: 20px;
 $pg-circular-xl-text-size: 30px;
+
+// checkbox size
+$checkbox-sm-width: 20px;
+$checkbox-sm-height: 20px;
+$checkbox-md-width: 24px;
+$checkbox-md-height: 24px;
+
+//checkbox container size
+$checkbox-container-sm-width: 38px;
+$checkbox-container-sm-height: 38px;
+$checkbox-container-md-width: 42px;
+$checkbox-container-md-height: 42px;

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -14,4 +14,4 @@
 @import '../components/Progress/Progress';
 
 // Checkbox
-@import '../components//Checkbox//Checkbox';
+@import '../components/Checkbox/Checkbox';


### PR DESCRIPTION
What was added: I added in the functionality for developers to pass predefined size props to the checkbox component. If nothing is pass, it will use medium by default. Currently, you can pass in small or medium and it will change the size of the checkbox by adding the appropriate class name so that it can be styled via css.

What was changed: I changed the initial checkbox component to have default props if not passed and made an icon list component for the svg to get data from inside CheckIcons.tsx. I changed the _mixin.scss and _variables.scss to include some css that is needed.